### PR TITLE
feat: 카카오 소셜 로그인 및 토큰 발급 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ out/
 src/main/resources/application.yml
 src/main/resources/application-local.yml
 src/main/resources/application-prod.yml
-src/main/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,21 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    // implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    // implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    // testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    //Jwt
+    implementation group: 'com.auth0', name: 'java-jwt', version: '3.14.0'
+    //Oauth2
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.4'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.4'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/efub/leadtoyproject/domain/member/domain/Member.java
+++ b/src/main/java/com/efub/leadtoyproject/domain/member/domain/Member.java
@@ -22,19 +22,21 @@ public class Member {
     @Column(name = "access_token")
     private String accessToken;
 
-    @Column(name = "refresh_token")
-    private String refreshToken;
+//    @Column(name = "refresh_token")
+//    private String refreshToken;
 
     // 양방향
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Cart cart;
 
     @Builder
-    public Member(Long memberId, @NotBlank String email, String accessToken, String refreshToken) {
+    public Member(Long memberId, @NotBlank String email) {
         this.memberId = memberId;
         this.email = email;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
         this.cart = new Cart(this);
+    }
+
+    public void updateAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 }

--- a/src/main/java/com/efub/leadtoyproject/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/efub/leadtoyproject/domain/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberId(Long memberId);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/efub/leadtoyproject/domain/member/service/MemberService.java
+++ b/src/main/java/com/efub/leadtoyproject/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.efub.leadtoyproject.domain.member.domain.Member;
 import com.efub.leadtoyproject.domain.member.repository.MemberRepository;
 import com.efub.leadtoyproject.global.exception.CustomException;
 import com.efub.leadtoyproject.global.exception.ErrorCode;
+import com.efub.leadtoyproject.global.login.AuthUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,17 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final AuthUtils authUtils;
 
     // (임시) 현재 회원 객체 가져오기
     public Member getCurrentMember() {
-        Member member = Member.builder()
-                .memberId(1L)
-                .email("testuser@gmail.com")
-                .accessToken("TestAccessToken")
-                .refreshToken("TestRefreshToken")
-                .build();
-        return member;
-        // return valMember(member.getMemberId()); - TODO: 추후 Auth 개발시 이 부분 로직 변경 예정
+        return authUtils.getMember();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/efub/leadtoyproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/efub/leadtoyproject/global/config/SecurityConfig.java
@@ -1,0 +1,104 @@
+package com.efub.leadtoyproject.global.config;
+import com.efub.leadtoyproject.global.jwt.JwtAuthenticationFilter;
+import com.efub.leadtoyproject.global.jwt.JwtExceptionFilter;
+import com.efub.leadtoyproject.global.oauth2.OAuth2FailureHandler;
+import com.efub.leadtoyproject.global.oauth2.OAuth2UserService;
+import com.efub.leadtoyproject.global.oauth2.OAuth2SuccessHandler;
+import jakarta.servlet.DispatcherType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final OAuth2UserService oAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() { // security를 적용하지 않을 리소스
+        return web -> web.ignoring()
+                // error endpoint를 열어줘야 함, favicon.ico 추가
+                .requestMatchers("/error", "/favicon.ico");
+    }
+
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000", "https://example.vercel.app/",
+                "http://localhost:5173", "http://localhost:5174",
+                "http://localhost:8080", "https://api.paladin.n-e.kr"));
+        configuration.addAllowedMethod("*"); //모든 Method 허용(POST, GET, ...)
+        configuration.addAllowedHeader("*"); //모든 Header 허용
+        configuration.setMaxAge(Duration.ofSeconds(3600)); //브라우저가 응답을 캐싱해도 되는 시간(1시간)
+        configuration.setAllowCredentials(true); //CORS 요청에서 자격 증명(쿠키, HTTP 헤더) 허용
+
+        configuration.addExposedHeader("Authorization"); // 클라이언트가 특정 헤더값에 접근 가능하도록 하기
+        configuration.addExposedHeader("Authorization-Refresh");
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**", configuration); //위에서 설정한 Configuration 적용
+        return source;
+    }
+
+    /* 여러 개의 보안 필터를 조합하여 하나의 보안 체인을 생성 */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable) //악의적인 공격 방어를 위해서 CSRF 토큰 사용 비활성화
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) //CORS 설정
+                .formLogin(AbstractHttpConfigurer::disable) //폼 기반 로그인을 비활성화->토큰 기반 인증 필요
+                .httpBasic(AbstractHttpConfigurer::disable) //HTTP 기본 인증을 비활성화->비밀번호를 평문으로 보내지 않음
+                .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션을 생성하지 않음->토큰 기반 인증 필요
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/oauth2/**").authenticated()
+                        .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
+                        .anyRequest().permitAll()
+                )
+                // oauth2 설정
+                .oauth2Login(oauth -> // OAuth2 로그인 기능에 대한 여러 설정의 진입점
+                        // OAuth2 로그인 성공 이후 사용자 정보를 가져올 때의 설정을 담당
+                        oauth.userInfoEndpoint(c -> c.userService(oAuth2UserService))
+                                // 로그인 성공 시 핸들러
+                                .successHandler(oAuth2SuccessHandler)
+                                // 로그인 실패 시 핸들러
+                                .failureHandler(oAuth2FailureHandler)
+                )
+                // jwt 관련 설정
+                .addFilterBefore(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), jwtAuthenticationFilter.getClass()) // 토큰 예외 핸들링
+//                // 인증 예외 핸들링
+//                .exceptionHandling((exceptions) -> exceptions
+//                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+//                        .accessDeniedHandler(new CustomAccessDeniedHandler()));
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/")
+                )
+        ;
+        return http.build();
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/efub/leadtoyproject/global/exception/ErrorCode.java
@@ -13,6 +13,10 @@ public enum ErrorCode {
     ERROR(400, "요청 처리에 실패했습니다."),
     ENTITY_NOT_FOUND(404, "해당 엔티티를 찾을 수 없습니다."),
 
+    // Oauth2
+    ILLEGAL_REGISTRATION_ID(500, "잘못된 registrationId입니다."),
+    INVALID_TOKEN(401, "잘못된 토큰입니다."),
+    INVALID_JWT_SIGNATURE(401, "토큰이 만료되었습니다."),
     // Member
     MEMBER_NOT_FOUND(404, "해당 사용자를 찾을 수 없습니다."),
 

--- a/src/main/java/com/efub/leadtoyproject/global/exception/TokenException.java
+++ b/src/main/java/com/efub/leadtoyproject/global/exception/TokenException.java
@@ -1,0 +1,10 @@
+package com.efub.leadtoyproject.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/efub/leadtoyproject/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/efub/leadtoyproject/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.efub.leadtoyproject.global.jwt;
+
+import com.efub.leadtoyproject.domain.member.domain.Member;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = resolveToken(request);
+
+        // accessToken 검증
+        if (tokenProvider.validateToken(accessToken)) {
+            setAuthentication(accessToken);
+        } else { // accessToken이 유효하지 않은 경우 처리
+            handleInvalidToken(request, response, filterChain);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(String accessToken) {
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private void handleInvalidToken(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws IOException, ServletException {
+        // 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            // 새로운 Access Token 발급
+            String newAccessToken = tokenProvider.generateAccessToken(authentication);
+            // 새로운 Access Token으로 인증 정보 업데이트
+            setAuthentication(newAccessToken);
+            // 응답 헤더에 새로운 Access Token 추가
+            response.setHeader(AUTHORIZATION, "Bearer " + newAccessToken);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader(AUTHORIZATION);
+        if (ObjectUtils.isEmpty(token) || !token.startsWith("Bearer ")) {
+            return null;
+        }
+        return token.substring(7);
+    }
+
+}

--- a/src/main/java/com/efub/leadtoyproject/global/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/efub/leadtoyproject/global/jwt/JwtExceptionFilter.java
@@ -1,0 +1,23 @@
+package com.efub.leadtoyproject.global.jwt;
+
+import com.efub.leadtoyproject.global.exception.TokenException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (TokenException e) {
+            response.sendError(e.getErrorCode().getStatus(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/jwt/JwtService.java
+++ b/src/main/java/com/efub/leadtoyproject/global/jwt/JwtService.java
@@ -1,0 +1,24 @@
+package com.efub.leadtoyproject.global.jwt;
+
+import com.efub.leadtoyproject.domain.member.domain.Member;
+import com.efub.leadtoyproject.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class JwtService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void saveOrUpdate(String email, String accessToken) {
+        Member member = memberRepository.findByEmail(email)
+                .orElse(Member.builder()
+                        .email(email)
+                        .build());
+        member.updateAccessToken(accessToken);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/jwt/TokenProvider.java
+++ b/src/main/java/com/efub/leadtoyproject/global/jwt/TokenProvider.java
@@ -1,0 +1,97 @@
+package com.efub.leadtoyproject.global.jwt;
+
+import com.efub.leadtoyproject.global.exception.ErrorCode;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import com.efub.leadtoyproject.global.exception.TokenException;
+
+import javax.crypto.SecretKey;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class TokenProvider {
+
+    @Value("${jwt.secret}")
+    private String key;
+    private SecretKey secretKey;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30L;
+    private static final String KEY_ROLE = "role";
+    private final JwtService jwtService;
+
+    @PostConstruct
+    private void setSecretKey() {
+        secretKey = Keys.hmacShaKeyFor(key.getBytes());
+    }
+
+    public String generateAccessToken(Authentication authentication) {
+        String accessToken = generateToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
+        String email = authentication.getName();
+        jwtService.saveOrUpdate(email, accessToken);
+        return accessToken;
+    }
+
+    private String generateToken(Authentication authentication, long expireTime) {
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + expireTime);
+
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining());
+
+        return Jwts.builder()
+                .subject(authentication.getName())
+                .claim(KEY_ROLE, authorities)
+                .issuedAt(now)
+                .expiration(expiredDate)
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
+        User principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+        return Collections.singletonList(new SimpleGrantedAuthority(
+                claims.get(KEY_ROLE).toString()));
+    }
+
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().after(new Date());
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser().verifyWith(secretKey).build()
+                    .parseSignedClaims(token).getPayload();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        } catch (MalformedJwtException e) {
+            throw new TokenException(ErrorCode.INVALID_TOKEN);
+        } catch (SecurityException e) {
+            throw new TokenException(ErrorCode.INVALID_JWT_SIGNATURE);
+        }
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/login/AuthDetails.java
+++ b/src/main/java/com/efub/leadtoyproject/global/login/AuthDetails.java
@@ -1,0 +1,73 @@
+package com.efub.leadtoyproject.global.login;
+
+import com.efub.leadtoyproject.domain.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public record AuthDetails (
+        Map<String, Object> attributes,
+        String attributeKey,
+        Member member) implements OAuth2User, UserDetails {
+
+    public Member getMember() {
+        return member;
+    }
+    
+    @Override
+    public String getName() {
+        return attributes.get(attributeKey).toString();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+                new SimpleGrantedAuthority(AuthRole.USER.getKey()));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/login/AuthRole.java
+++ b/src/main/java/com/efub/leadtoyproject/global/login/AuthRole.java
@@ -1,0 +1,15 @@
+package com.efub.leadtoyproject.global.login;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthRole { // Oauth2에서 사용
+
+    GUEST("ROLE_GUEST", "손님"),
+    USER("ROLE_USER", "사용자");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/com/efub/leadtoyproject/global/login/AuthUtils.java
+++ b/src/main/java/com/efub/leadtoyproject/global/login/AuthUtils.java
@@ -1,0 +1,58 @@
+package com.efub.leadtoyproject.global.login;
+
+import com.efub.leadtoyproject.domain.member.domain.Member;
+import com.efub.leadtoyproject.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class AuthUtils {
+
+    public Member getMember() {
+        log.info("AuthUtils - getMember 함수 진입");
+        Object principalObject = getPrincipal();
+
+        log.info("principal이 UserDetails 인스턴스인지 확인");
+        if (principalObject instanceof UserDetails) {
+            AuthDetails authDetails = (AuthDetails) principalObject;
+            return authDetails.getMember();
+        }
+        return null;
+    }
+
+
+    public AuthRole getCurrentUserRole() {
+        log.info("AuthUtils - getCurrentUserRole 함수 진입");
+        Object principalObject = getPrincipal();
+
+        log.info("principal이 UserDetails 인스턴스인지 확인");
+        if (principalObject instanceof UserDetails) {
+            log.info("성공");
+            UserDetails userDetails = (UserDetails) principalObject;
+
+            // UserDetails에서 권한 목록 가져오기
+            Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
+            GrantedAuthority firstAuthority = authorities.iterator().next();
+            String authorityString = firstAuthority.getAuthority();
+
+            // UserDetails 인스턴스에서 Role String 획득
+            return AuthRole.valueOf(authorityString);
+        }
+        return null;
+    }
+
+    public Object getPrincipal() {
+        log.info("AuthUtils - getPrincipal 함수 진입");
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication.getPrincipal();
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2Attributes.java
+++ b/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2Attributes.java
@@ -1,0 +1,35 @@
+package com.efub.leadtoyproject.global.oauth2;
+
+import com.efub.leadtoyproject.domain.member.domain.Member;
+import com.efub.leadtoyproject.global.exception.CustomException;
+import com.efub.leadtoyproject.global.exception.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuth2Attributes {
+    private String oauth2UserEmail;
+
+    @Builder
+    private OAuth2Attributes(String oauth2UserEmail) {
+        this.oauth2UserEmail = oauth2UserEmail;
+    }
+    
+    public static OAuth2Attributes ofKakao(String registrationId, Map<String, Object> attributes) {
+        if (!registrationId.equals("kakao"))
+            throw new CustomException(ErrorCode.ILLEGAL_REGISTRATION_ID);
+        Map<String, Object> accountAttributes = (Map<String, Object>) attributes.get("kakao_account");
+
+        return OAuth2Attributes.builder()
+                .oauth2UserEmail(String.valueOf(accountAttributes.get("email")))
+                .build();
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .email(oauth2UserEmail)
+                .build();
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2FailureHandler.java
@@ -1,0 +1,24 @@
+package com.efub.leadtoyproject.global.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        log.info("카카오 로그인에 실패하였습니다.");
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"message\": \"카카오 로그인에 실패하였습니다.\"}");
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,33 @@
+package com.efub.leadtoyproject.global.oauth2;
+
+import com.efub.leadtoyproject.global.jwt.TokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        // accessToken 발급
+        String accessToken = tokenProvider.generateAccessToken(authentication);
+        log.info("카카오 로그인에 성공하였습니다. 발급된 accessToken: " + accessToken);
+
+        // 헤더 Authorization에 Bearer Token 담기
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.sendRedirect("/redirect"); // 로그인에 성공 시 /redirect 으로 이동됨
+    }
+}

--- a/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2UserService.java
+++ b/src/main/java/com/efub/leadtoyproject/global/oauth2/OAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.efub.leadtoyproject.global.oauth2;
+
+
+import com.efub.leadtoyproject.domain.member.domain.Member;
+import com.efub.leadtoyproject.domain.member.repository.MemberRepository;
+import com.efub.leadtoyproject.global.login.AuthDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class OAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 유저 정보(attributes) 가져오기
+        Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
+
+        // 2. registrationId 가져오기 (third-party id)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // 3. userNameAttributeName 가져오기.
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        // 4. 유저 정보 dto 생성
+        OAuth2Attributes oAuth2Attributes = OAuth2Attributes.ofKakao(registrationId, oAuth2UserAttributes);
+
+        // 5. 회원가입 및 로그인
+        Member member = getOrSave(oAuth2Attributes);
+
+        // 6. AuthDetails 로 반환
+        log.info("OAuth2UserService - loadUser() : AuthDetails로 반환합니다.");
+        return new AuthDetails(oAuth2UserAttributes, userNameAttributeName, member);
+    }
+
+    private Member getOrSave(OAuth2Attributes oAuth2Attributes) {
+        Member member = memberRepository.findByEmail(oAuth2Attributes.getOauth2UserEmail())
+                .orElseGet(oAuth2Attributes::toEntity);
+        return memberRepository.save(member);
+    }
+}


### PR DESCRIPTION
- 카카오 소셜 로그인(OAuth2), 액세스 토큰(JWT), Spring Security 관련하여 개발하였습니다.
- 리프레싱은 구현의 간단화를 위하여 생략하고 invalid한 토큰이면 재발급하도록 하였습니다.